### PR TITLE
Fix suspend/resume functions, support multiple instances

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -8,12 +8,16 @@ module.exports = NodeHelper.create({
     },
 
     sendOffer: function(payload) {
+        console.log(`Offer requested for ${payload.identifier}`);
         fetch(payload.url, {
             method: 'POST',
             body: new URLSearchParams({ data: payload.sdp })
           })
             .then(response => response.text())
-            .then(response_data => this.sendSocketNotification(`ANSWER_${payload.identifier}`, response_data));
+            .then(response_data => this.sendSocketNotification(`ANSWER_${payload.identifier}`, response_data))
+            .catch(error=>{
+                console.error(error);
+            });
     },
 
     socketNotificationReceived: function(notification, payload) {


### PR DESCRIPTION
Changes in this PR:

- Fix suspend and resume functions to properly close connections when not in use
- Support multiple instances of the module
- Rename `_init` function to something more descriptive
- Logs for RTC negotiation to support troubleshooting
